### PR TITLE
Setup environment to can configure api path and authentication

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: node_js

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,3 @@
 language: node_js
+node_js:
+  - "lts/*"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # jira-board-printable
 
+[![Build Status](https://travis-ci.org/nthungvn/jira-board-printable.svg?branch=master)](https://travis-ci.org/nthungvn/jira-board-printable)
+
 > Every sprint we need to wait our PO activate the sprint before we can print all tasks and stories. Now we will supported the team can print all tasks and stories of specifics sprint witout waiting our PO.
 
 ## Build Setup

--- a/config/dev.env.js
+++ b/config/dev.env.js
@@ -1,0 +1,4 @@
+module.exports = merge(prodEnv, {
+  NODE_ENV: '"development"',
+  DEBUG_MODE: true // this overrides the DEBUG_MODE value of prod.env
+})

--- a/config/prod.env.js
+++ b/config/prod.env.js
@@ -1,0 +1,6 @@
+module.exports = {
+  NODE_ENV: '"production"',
+  DEBUG_MODE: false,
+  'API_BASE_PATH': JSON.stringify(process.env.API_BASE_PATH),
+  'API_AUTHORIZATION': JSON.stringify(process.env.AUTHORIZATION)
+}

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "vue": "^2.5.11",
+    "vue-resource": "^1.3.5",
     "vuetify": "^0.17.7"
   },
   "browserslist": [

--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,11 @@
 import Vue from 'vue'
+import VueResource from 'vue-resource'
 import App from './App.vue'
+
+Vue.use(VueResource);
+
+Vue.http.options.root = process.env.API_BASE_PATH;
+Vue.http.headers.common['Authorization'] = process.env.API_AUTHORIZATION;
 
 new Vue({
   el: '#app',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -53,6 +53,14 @@ module.exports = {
   performance: {
     hints: false
   },
+  plugins: [
+    new webpack.DefinePlugin({
+      'process.env': {
+        'API_BASE_PATH': JSON.stringify(process.env.API_BASE_PATH),
+        'AUTHORIZATION': JSON.stringify(process.env.AUTHORIZATION)
+      }
+    })
+  ],
   devtool: '#eval-source-map'
 }
 


### PR DESCRIPTION
We can set up 2 necessary variables for call JIRA API:

- API base path: **API_BASE_PATH**
- API authentication in base64: **API_AUTHORIZATION**

Set these variables like other variables in your Opera System before run application or build.